### PR TITLE
Fix coordinate conversion overflow at image edges

### DIFF
--- a/js/image-processing.js
+++ b/js/image-processing.js
@@ -256,9 +256,17 @@ Object.assign(ImageAnalyzer.prototype, {
         }
         
         // 元画像座標に変換
-        const originalX = Math.round((imageX / this.displayedWidth) * this.currentImage.width);
-        const originalY = Math.round((imageY / this.displayedHeight) * this.currentImage.height);
-        
+        // Math.round を使用すると右端/下端付近で width/height を超える値に丸められることがあるため
+        // Math.floor で切り捨て、さらに最大値を width-1 / height-1 に制限する
+        const originalX = Math.min(
+            Math.floor((imageX / this.displayedWidth) * this.currentImage.width),
+            this.currentImage.width - 1
+        );
+        const originalY = Math.min(
+            Math.floor((imageY / this.displayedHeight) * this.currentImage.height),
+            this.currentImage.height - 1
+        );
+
         return { x: originalX, y: originalY };
     },
 


### PR DESCRIPTION
## Summary
- Prevent display-to-original coordinate mapping from exceeding image bounds by flooring values and clamping to width/height-1

## Testing
- `node -e "const width=100;function convert(imageX){return Math.min(Math.floor((imageX/100)*width),width-1);}console.log('convert 99.75 ->', convert(99.75));console.log('convert 100 ->', convert(100));"`


------
https://chatgpt.com/codex/tasks/task_e_688e16d991b48332a690d42c1f54a75f