### PR TITLE
feat: add line profile analysis

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -432,6 +432,13 @@ body {
     margin-bottom: 10px;
 }
 
+.line-profile-mode-selector {
+    display: flex;
+    gap: 5px;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+}
+
 .mode-btn {
     padding: 6px 12px;
     border: 1px solid #dee2e6;

--- a/css/styles.css
+++ b/css/styles.css
@@ -426,6 +426,12 @@ body {
     flex-wrap: wrap;
 }
 
+.draw-mode-selector {
+    display: flex;
+    gap: 5px;
+    margin-bottom: 10px;
+}
+
 .mode-btn {
     padding: 6px 12px;
     border: 1px solid #dee2e6;
@@ -516,6 +522,13 @@ body {
     background: white;
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    cursor: pointer;
+    transition: transform 0.2s ease;
+}
+
+#lineProfileChart:hover {
+    transform: scale(1.02);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .peak-info {

--- a/css/styles.css
+++ b/css/styles.css
@@ -511,6 +511,20 @@ body {
     margin-top: 5px;
 }
 
+/* ラインプロファイル */
+#lineProfileChart {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.peak-info {
+    margin-top: 8px;
+    text-align: center;
+    font-size: 0.85rem;
+    color: #495057;
+}
+
 .histogram-tooltip {
     position: absolute;
     background: rgba(0, 0, 0, 0.8);

--- a/index.html
+++ b/index.html
@@ -153,6 +153,15 @@
                         💡 クリックで拡大表示 | マウスでホバー確認
                     </p>
                 </div>
+
+                <div class="panel">
+                    <h3>ラインプロファイル</h3>
+                    <button id="lineProfileBtn" class="param-button primary" style="margin-bottom:10px;">ライン測定</button>
+                    <div class="histogram-container" style="height:180px;">
+                        <canvas id="lineProfileChart" width="300" height="150"></canvas>
+                    </div>
+                    <div id="peakInfo" class="peak-info">ピークなし</div>
+                </div>
             </div>
         </div>
     </div>
@@ -180,6 +189,7 @@
     <script src="js/mouse-operations.js"></script>
     <script src="js/analysis.js"></script>
     <script src="js/histogram.js"></script>
+    <script src="js/line-profile.js"></script>
     <script src="js/events.js"></script>
     <script src="js/ui-controls.js"></script>
     <script src="js/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -25,6 +25,11 @@
                     </ul>
                 </div>
 
+                <div class="draw-mode-selector">
+                    <button id="roiModeBtn" class="mode-btn active">Roi</button>
+                    <button id="lineModeBtn" class="mode-btn">Line</button>
+                </div>
+
                 <div id="dropZone" class="drop-zone">
                     <p>📁 画像ファイルをここにドロップ</p>
                     <small>または、クリックしてファイルを選択 (JPG, PNG, BMP, TIFF, WebP, GIF対応)</small>
@@ -156,7 +161,6 @@
 
                 <div class="panel">
                     <h3>ラインプロファイル</h3>
-                    <button id="lineProfileBtn" class="param-button primary" style="margin-bottom:10px;">ライン測定</button>
                     <div class="histogram-container" style="height:180px;">
                         <canvas id="lineProfileChart" width="300" height="150"></canvas>
                     </div>
@@ -179,6 +183,18 @@
             </div>
             <div id="histogramInfo" class="histogram-info">
                 <!-- JavaScript で動的に生成 -->
+            </div>
+        </div>
+    </div>
+
+    <!-- ラインプロファイル拡大モーダル -->
+    <div id="lineProfileModal" class="histogram-modal">
+        <div class="histogram-modal-content">
+            <button class="histogram-close" onclick="closeLineProfileModal()">&times;</button>
+            <h3>ラインプロファイル詳細表示</h3>
+            <p class="histogram-modal-help">💡 横スクロールで詳細を確認できます</p>
+            <div class="histogram-scroll-container">
+                <canvas id="lineProfileChartLarge" height="400"></canvas>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
             <h3>ラインプロファイル詳細表示</h3>
             <p class="histogram-modal-help">💡 横スクロールで詳細を確認できます</p>
             <div class="histogram-scroll-container">
-                <canvas id="lineProfileChartLarge" height="400"></canvas>
+                <canvas id="lineProfileChartLarge" height="480"></canvas>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -161,6 +161,13 @@
 
                 <div class="panel">
                     <h3>ラインプロファイル</h3>
+                    <div class="histogram-mode-selector line-profile-mode-selector">
+                        <button class="mode-btn active" data-mode="brightness">輝度</button>
+                        <button class="mode-btn" data-mode="red">R</button>
+                        <button class="mode-btn" data-mode="green">G</button>
+                        <button class="mode-btn" data-mode="blue">B</button>
+                        <button class="mode-btn" data-mode="rgb-overlay">RGB重畳</button>
+                    </div>
                     <div class="histogram-container" style="height:180px;">
                         <canvas id="lineProfileChart" width="300" height="150"></canvas>
                     </div>

--- a/js/core.js
+++ b/js/core.js
@@ -158,11 +158,11 @@ class ImageAnalyzer {
             // 解析データのリセット
             this.isAnalyzing = false;
             this.currentHistogramData = null;
-            
+
             // UI要素のリセット
             this.canvas.classList.add('hidden');
             this.dropZone.classList.remove('hidden');
-
+           
             if (this.lineAnalyzer) {
                 this.lineAnalyzer.graph.draw({ r: [], g: [], b: [], brightness: [] });
                 if (this.lineAnalyzer.peakInfo) {
@@ -171,6 +171,10 @@ class ImageAnalyzer {
                 this.lineAnalyzer.lastValues = null;
                 this.lineAnalyzer.closeModal && this.lineAnalyzer.closeModal();
             }
+
+             const resetBtn = document.getElementById('resetView');
+            if (resetBtn) resetBtn.classList.add('hidden');
+
             
             // ステータス表示
             this.setStatusMessage('アプリケーションをリセットしました');

--- a/js/core.js
+++ b/js/core.js
@@ -50,7 +50,8 @@ class ImageAnalyzer {
         this.startX = 0;
         this.startY = 0;
         this.currentRect = null;
-        
+        this.drawMode = 'rect';
+
         // 解析関連
         this.isAnalyzing = false; // 無限再帰防止フラグ
         this.currentHistogramData = null;
@@ -61,6 +62,9 @@ class ImageAnalyzer {
         this.histogramCtx = null;
         this.histogramLargeCanvas = null;
         this.histogramLargeCtx = null;
+
+        // ラインプロファイル
+        this.lineAnalyzer = null;
     }
 
     /**
@@ -72,15 +76,18 @@ class ImageAnalyzer {
         try {
             // イベントリスナーの設定
             this.initEventListeners();
-            
+
             // ヒストグラム機能の初期化
             this.initHistogramChart();
             this.initHistogramModal();
             this.initHistogramControls();
-            
+
             // UI制御の初期化
             this.initUIControls();
-            
+
+            // ラインプロファイル機能
+            this.lineAnalyzer = new LineAnalyzer(this);
+
         } catch (error) {
             console.error('Error initializing modules:', error);
         }
@@ -143,6 +150,7 @@ class ImageAnalyzer {
             // 描画状態のリセット
             this.isDrawing = false;
             this.currentRect = null;
+            this.drawMode = 'rect';
             
             // 解析データのリセット
             this.isAnalyzing = false;
@@ -151,6 +159,13 @@ class ImageAnalyzer {
             // UI要素のリセット
             this.canvas.classList.add('hidden');
             this.dropZone.classList.remove('hidden');
+
+            if (this.lineAnalyzer) {
+                this.lineAnalyzer.graph.draw({ r: [], g: [], b: [], brightness: [] });
+                if (this.lineAnalyzer.peakInfo) {
+                    this.lineAnalyzer.peakInfo.textContent = 'ピークなし';
+                }
+            }
             
             // ステータス表示
             this.setStatusMessage('アプリケーションをリセットしました');

--- a/js/core.js
+++ b/js/core.js
@@ -151,6 +151,9 @@ class ImageAnalyzer {
             this.isDrawing = false;
             this.currentRect = null;
             this.drawMode = 'rect';
+            if (this.updateModeButtons) {
+                this.updateModeButtons('rect');
+            }
             
             // 解析データのリセット
             this.isAnalyzing = false;
@@ -165,6 +168,8 @@ class ImageAnalyzer {
                 if (this.lineAnalyzer.peakInfo) {
                     this.lineAnalyzer.peakInfo.textContent = 'ピークなし';
                 }
+                this.lineAnalyzer.lastValues = null;
+                this.lineAnalyzer.closeModal && this.lineAnalyzer.closeModal();
             }
             
             // ステータス表示

--- a/js/events.js
+++ b/js/events.js
@@ -113,26 +113,42 @@ Object.assign(ImageAnalyzer.prototype, {
     initCanvasEvents() {
         if (!this.canvas) return;
 
-        // マウスダウン - 矩形描画開始
+        // マウスダウン
         this.canvas.addEventListener('mousedown', (e) => {
-            this.startDrawing(e);
+            if (this.drawMode === 'rect') {
+                this.startDrawing(e);
+            } else if (this.drawMode === 'line' && this.lineAnalyzer) {
+                this.lineAnalyzer.start(e);
+            }
         });
 
-        // マウスムーブ - 矩形描画・カーソル情報更新
+        // マウスムーブ
         this.canvas.addEventListener('mousemove', (e) => {
-            this.drawRectangle(e);
+            if (this.drawMode === 'rect') {
+                this.drawRectangle(e);
+            } else if (this.drawMode === 'line' && this.lineAnalyzer) {
+                this.lineAnalyzer.draw(e);
+            }
             this.updateCursorInfo(e);
         });
 
-        // マウスアップ - 矩形描画終了
+        // マウスアップ
         this.canvas.addEventListener('mouseup', (e) => {
-            this.endDrawing(e);
+            if (this.drawMode === 'rect') {
+                this.endDrawing(e);
+            } else if (this.drawMode === 'line' && this.lineAnalyzer) {
+                this.lineAnalyzer.end(e);
+            }
         });
 
         // マウスリーブ - 描画中止・カーソル情報クリア
         this.canvas.addEventListener('mouseleave', (e) => {
-            if (this.isDrawing) {
-                this.endDrawing(e);
+            if (this.drawMode === 'rect') {
+                if (this.isDrawing) {
+                    this.endDrawing(e);
+                }
+            } else if (this.drawMode === 'line' && this.lineAnalyzer && this.lineAnalyzer.drawer.isDrawing) {
+                this.lineAnalyzer.end(e);
             }
             this.clearCursorInfo();
         });

--- a/js/events.js
+++ b/js/events.js
@@ -24,7 +24,10 @@ Object.assign(ImageAnalyzer.prototype, {
         
         // Canvas操作イベント
         this.initCanvasEvents();
-        
+
+        // 描画モード切り替えボタン
+        this.initModeButtons();
+
         // ウィンドウイベント
         this.initWindowEvents();
         
@@ -108,6 +111,44 @@ Object.assign(ImageAnalyzer.prototype, {
     },
 
     /**
+     * 描画モード切り替えボタンの初期化
+     */
+    initModeButtons() {
+        const roiBtn = document.getElementById('roiModeBtn');
+        const lineBtn = document.getElementById('lineModeBtn');
+        if (!roiBtn || !lineBtn) return;
+
+        roiBtn.addEventListener('click', () => {
+            this.drawMode = 'rect';
+            this.updateModeButtons('rect');
+            this.setStatusMessage('矩形モード');
+        });
+
+        lineBtn.addEventListener('click', () => {
+            if (!this.lineAnalyzer) return;
+            this.lineAnalyzer.activate();
+            this.updateModeButtons('line');
+        });
+    },
+
+    /**
+     * 描画モードボタンの状態更新
+     */
+    updateModeButtons(mode) {
+        const roiBtn = document.getElementById('roiModeBtn');
+        const lineBtn = document.getElementById('lineModeBtn');
+        if (!roiBtn || !lineBtn) return;
+
+        if (mode === 'line') {
+            lineBtn.classList.add('active');
+            roiBtn.classList.remove('active');
+        } else {
+            roiBtn.classList.add('active');
+            lineBtn.classList.remove('active');
+        }
+    },
+
+    /**
      * Canvas操作イベントの初期化
      */
     initCanvasEvents() {
@@ -175,6 +216,11 @@ Object.assign(ImageAnalyzer.prototype, {
         // キーボードイベント（ESCキーでモーダル閉じる）
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
+                const lineModal = document.getElementById('lineProfileModal');
+                if (lineModal && lineModal.style.display === 'flex') {
+                    if (this.lineAnalyzer) this.lineAnalyzer.closeModal();
+                    return;
+                }
                 const modal = document.getElementById('histogramModal');
                 if (modal && modal.style.display === 'flex') {
                     this.closeHistogramModal();
@@ -188,6 +234,14 @@ Object.assign(ImageAnalyzer.prototype, {
             modal.addEventListener('click', (e) => {
                 if (e.target.id === 'histogramModal') {
                     this.closeHistogramModal();
+                }
+            });
+        }
+        const lineModal = document.getElementById('lineProfileModal');
+        if (lineModal) {
+            lineModal.addEventListener('click', (e) => {
+                if (e.target.id === 'lineProfileModal' && this.lineAnalyzer) {
+                    this.lineAnalyzer.closeModal();
                 }
             });
         }

--- a/js/events.js
+++ b/js/events.js
@@ -164,41 +164,65 @@ Object.assign(ImageAnalyzer.prototype, {
 
         // マウスダウン
         this.canvas.addEventListener('mousedown', (e) => {
-            if (this.drawMode === 'rect') {
+            if (this.drawMode === 'rect' && e.button === 0) {
                 this.startDrawing(e);
-            } else if (this.drawMode === 'line' && this.lineAnalyzer) {
+            } else if (this.drawMode === 'line' && this.lineAnalyzer && e.button === 0) {
                 this.lineAnalyzer.start(e);
+            }
+            else if (e.button === 1 || e.button === 2) {
+                e.preventDefault();
+                this.startPan(e);
             }
         });
 
         // マウスムーブ
         this.canvas.addEventListener('mousemove', (e) => {
-            if (this.drawMode === 'rect') {
-                this.drawRectangle(e);
-            } else if (this.drawMode === 'line' && this.lineAnalyzer) {
-                this.lineAnalyzer.draw(e);
+            
+             if (this.isPanning) {
+                e.preventDefault();
+                this.panImage(e);
+            } 
+            else{
+                if (this.drawMode === 'rect') {
+                    this.drawRectangle(e);
+                } else if (this.drawMode === 'line' && this.lineAnalyzer) {
+                    this.lineAnalyzer.draw(e);
+                }
+                this.updateCursorInfo(e);
             }
-            this.updateCursorInfo(e);
+
         });
 
         // マウスアップ
         this.canvas.addEventListener('mouseup', (e) => {
-            if (this.drawMode === 'rect') {
-                this.endDrawing(e);
-            } else if (this.drawMode === 'line' && this.lineAnalyzer) {
-                this.lineAnalyzer.end(e);
+            if (this.isPanning) {
+                this.endPan();
+            } 
+            else
+            {
+                if (this.drawMode === 'rect') {
+                    this.endDrawing(e);
+                } else if (this.drawMode === 'line' && this.lineAnalyzer) {
+                    this.lineAnalyzer.end(e);
+                }
             }
+           
         });
 
         // マウスリーブ - 描画中止・カーソル情報クリア
         this.canvas.addEventListener('mouseleave', (e) => {
-            if (this.drawMode === 'rect') {
-                if (this.isDrawing) {
-                    this.endDrawing(e);
-                }
-            } else if (this.drawMode === 'line' && this.lineAnalyzer && this.lineAnalyzer.drawer.isDrawing) {
-                this.lineAnalyzer.end(e);
+             if (this.isPanning) {
+                this.endPan();
             }
+             if (this.isDrawing) {
+                if (this.drawMode === 'rect') {
+                    if (this.isDrawing) {
+                        this.endDrawing(e);
+                    }
+                } else if (this.drawMode === 'line' && this.lineAnalyzer && this.lineAnalyzer.drawer.isDrawing) {
+                    this.lineAnalyzer.end(e);
+                }
+             }
             this.clearCursorInfo();
         });
 

--- a/js/events.js
+++ b/js/events.js
@@ -122,6 +122,14 @@ Object.assign(ImageAnalyzer.prototype, {
             this.drawMode = 'rect';
             this.updateModeButtons('rect');
             this.setStatusMessage('矩形モード');
+            if (this.currentRect) {
+                this.redrawCanvas();
+                const r = this.currentRect;
+                this.drawSelectionRectangle(r.x, r.y, r.x + r.width, r.y + r.height);
+            }
+            if (this.currentHistogramData) {
+                setTimeout(() => this.safeUpdateHistogram(), 10);
+            }
         });
 
         lineBtn.addEventListener('click', () => {

--- a/js/histogram.js
+++ b/js/histogram.js
@@ -75,7 +75,7 @@ Object.assign(ImageAnalyzer.prototype, {
      * ヒストグラム制御の初期化
      */
     initHistogramControls() {
-        const modeButtons = document.querySelectorAll('.mode-btn');
+        const modeButtons = document.querySelectorAll('.histogram-mode-selector .mode-btn');
         
         modeButtons.forEach(btn => {
             btn.addEventListener('click', (e) => {

--- a/js/histogram.js
+++ b/js/histogram.js
@@ -420,7 +420,8 @@ Object.assign(ImageAnalyzer.prototype, {
     safeUpdateHistogram() {
         try {
             if (!this.currentHistogramData || this.isAnalyzing) return;
-            
+            if (this.drawMode === 'line') return;
+
             const mode = this.currentHistogramMode;
             
             if (mode === 'rgb-overlay') {
@@ -836,7 +837,7 @@ Object.assign(ImageAnalyzer.prototype, {
      * レガシー互換性関数
      */
     updateHistogramDisplay() {
-        if (!this.isAnalyzing) {
+        if (!this.isAnalyzing && this.drawMode !== 'line') {
             setTimeout(() => {
                 this.safeUpdateHistogram();
             }, 10);

--- a/js/image-processing.js
+++ b/js/image-processing.js
@@ -92,10 +92,18 @@ Object.assign(ImageAnalyzer.prototype, {
         const specificResult = document.getElementById('specificResult');
         if (specificInput) specificInput.value = '';
         if (specificResult) specificResult.textContent = '--';
-        
+
         // ヒストグラムをリセット
         if (this.drawEmptyHistogram) {
             this.drawEmptyHistogram();
+        }
+
+        // ラインプロファイルをリセット
+        if (this.lineAnalyzer) {
+            this.lineAnalyzer.graph.draw({ r: [], g: [], b: [], brightness: [] });
+            if (this.lineAnalyzer.peakInfo) {
+                this.lineAnalyzer.peakInfo.textContent = 'ピークなし';
+            }
         }
     },
 

--- a/js/line-profile.js
+++ b/js/line-profile.js
@@ -184,6 +184,29 @@ class LineGraph {
         const height = this.largeCanvas.height;
         this.largeCtx.clearRect(0, 0, width, height);
         const maxVal = 255;
+        const step = Math.max(1, Math.floor(5 / this.largeZoom));
+
+        // 軸
+        this.largeCtx.strokeStyle = '#dee2e6';
+        this.largeCtx.lineWidth = 1;
+        this.largeCtx.beginPath();
+        this.largeCtx.moveTo(0, 0);
+        this.largeCtx.lineTo(0, height);
+        this.largeCtx.lineTo(width, height);
+        this.largeCtx.stroke();
+
+        // 軸ラベル
+        this.largeCtx.fillStyle = '#495057';
+        this.largeCtx.font = '12px sans-serif';
+        this.largeCtx.textAlign = 'center';
+        this.largeCtx.fillText('距離(px)', width / 2, height - 4);
+        this.largeCtx.save();
+        this.largeCtx.translate(12, height / 2);
+        this.largeCtx.rotate(-Math.PI / 2);
+        this.largeCtx.fillText('画素値', 0, 0);
+        this.largeCtx.restore();
+
+        this.largeCtx.textAlign = 'left';
 
         const drawChannel = (data, color) => {
             this.largeCtx.beginPath();
@@ -197,15 +220,20 @@ class LineGraph {
             this.largeCtx.lineWidth = 1;
             this.largeCtx.stroke();
 
-            this.largeCtx.fillStyle = color;
             this.largeCtx.font = '10px sans-serif';
-            for (let i = 0; i < len; i += 5) {
+            for (let i = 0; i < len; i += step) {
                 const x = (i / (len - 1)) * width;
                 const y = height - (data[i] / maxVal) * height;
+                this.largeCtx.fillStyle = color;
                 this.largeCtx.beginPath();
                 this.largeCtx.arc(x, y, 2, 0, Math.PI * 2);
                 this.largeCtx.fill();
                 this.largeCtx.fillText(data[i], x + 2, y - 2);
+
+                this.largeCtx.fillStyle = '#495057';
+                this.largeCtx.textAlign = 'center';
+                this.largeCtx.fillText(i, x, height - 6);
+                this.largeCtx.textAlign = 'left';
             }
         };
 

--- a/js/line-profile.js
+++ b/js/line-profile.js
@@ -1,0 +1,208 @@
+/**
+ * Line profile analysis module
+ * Provides line drawing, pixel sampling, graphing and peak detection.
+ */
+
+class LineDrawer {
+    constructor(imageAnalyzer) {
+        this.analyzer = imageAnalyzer;
+        this.isDrawing = false;
+        this.startPoint = null;
+    }
+
+    reset() {
+        this.isDrawing = false;
+        this.startPoint = null;
+    }
+
+    getCanvasPos(e) {
+        const rect = this.analyzer.canvas.getBoundingClientRect();
+        const scaleX = this.analyzer.canvas.width / rect.width;
+        const scaleY = this.analyzer.canvas.height / rect.height;
+        return {
+            x: (e.clientX - rect.left) * scaleX,
+            y: (e.clientY - rect.top) * scaleY
+        };
+    }
+
+    start(e) {
+        this.isDrawing = true;
+        this.startPoint = this.getCanvasPos(e);
+        this.analyzer.redrawCanvas();
+    }
+
+    draw(e) {
+        if (!this.isDrawing) return;
+        const current = this.getCanvasPos(e);
+        this.analyzer.redrawCanvas();
+        const ctx = this.analyzer.ctx;
+        ctx.save();
+        ctx.strokeStyle = '#ff4757';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(this.startPoint.x, this.startPoint.y);
+        ctx.lineTo(current.x, current.y);
+        ctx.stroke();
+        ctx.restore();
+    }
+
+    end(e) {
+        if (!this.isDrawing) return null;
+        const endPoint = this.getCanvasPos(e);
+        this.isDrawing = false;
+        this.analyzer.redrawCanvas();
+        // Draw final line
+        const ctx = this.analyzer.ctx;
+        ctx.save();
+        ctx.strokeStyle = '#ff4757';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(this.startPoint.x, this.startPoint.y);
+        ctx.lineTo(endPoint.x, endPoint.y);
+        ctx.stroke();
+        ctx.restore();
+        return { start: this.startPoint, end: endPoint };
+    }
+}
+
+class PixelSampler {
+    static sample(analyzer, start, end) {
+        const img = analyzer.currentImage;
+        if (!img) return null;
+
+        const scaleX = img.width / analyzer.displayedWidth;
+        const scaleY = img.height / analyzer.displayedHeight;
+
+        const x0 = Math.round((start.x - analyzer.imageOffsetX) * scaleX);
+        const y0 = Math.round((start.y - analyzer.imageOffsetY) * scaleY);
+        const x1 = Math.round((end.x - analyzer.imageOffsetX) * scaleX);
+        const y1 = Math.round((end.y - analyzer.imageOffsetY) * scaleY);
+
+        const dx = Math.abs(x1 - x0);
+        const sx = x0 < x1 ? 1 : -1;
+        const dy = -Math.abs(y1 - y0);
+        const sy = y0 < y1 ? 1 : -1;
+        let err = dx + dy;
+        let x = x0;
+        let y = y0;
+
+        const values = { r: [], g: [], b: [], brightness: [] };
+        while (true) {
+            const pixel = analyzer.getOriginalPixelData(x, y);
+            if (pixel) {
+                values.r.push(pixel.r);
+                values.g.push(pixel.g);
+                values.b.push(pixel.b);
+                values.brightness.push(pixel.brightness);
+            }
+            if (x === x1 && y === y1) break;
+            const e2 = 2 * err;
+            if (e2 >= dy) { err += dy; x += sx; }
+            if (e2 <= dx) { err += dx; y += sy; }
+        }
+        return values;
+    }
+}
+
+class PeakDetector {
+    static findPeaks(values, threshold = 5) {
+        const peaks = [];
+        for (let i = 1; i < values.length - 1; i++) {
+            if (values[i] > values[i - 1] && values[i] > values[i + 1]) {
+                if ((values[i] - values[i - 1] > threshold) && (values[i] - values[i + 1] > threshold)) {
+                    peaks.push({ index: i, value: values[i] });
+                }
+            }
+        }
+        return peaks;
+    }
+}
+
+class LineGraph {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.ctx = canvas?.getContext('2d');
+    }
+
+    draw(values) {
+        if (!this.ctx || !values) return;
+        const ctx = this.ctx;
+        const width = this.canvas.width;
+        const height = this.canvas.height;
+        ctx.clearRect(0, 0, width, height);
+        const len = values.brightness.length;
+        if (len === 0) return;
+        const maxVal = 255;
+
+        const drawChannel = (data, color) => {
+            ctx.beginPath();
+            data.forEach((v, i) => {
+                const x = (i / (len - 1)) * width;
+                const y = height - (v / maxVal) * height;
+                if (i === 0) ctx.moveTo(x, y);
+                else ctx.lineTo(x, y);
+            });
+            ctx.strokeStyle = color;
+            ctx.lineWidth = 1;
+            ctx.stroke();
+        };
+
+        drawChannel(values.r, 'red');
+        drawChannel(values.g, 'green');
+        drawChannel(values.b, 'blue');
+        drawChannel(values.brightness, 'black');
+    }
+}
+
+class LineAnalyzer {
+    constructor(imageAnalyzer) {
+        this.imageAnalyzer = imageAnalyzer;
+        this.drawer = new LineDrawer(imageAnalyzer);
+        this.graph = new LineGraph(document.getElementById('lineProfileChart'));
+        this.peakInfo = document.getElementById('peakInfo');
+        const btn = document.getElementById('lineProfileBtn');
+        if (btn) {
+            btn.addEventListener('click', () => this.activate());
+        }
+    }
+
+    activate() {
+        if (!this.imageAnalyzer.currentImage) {
+            this.imageAnalyzer.setStatusMessage('まず画像を読み込んでください');
+            return;
+        }
+        this.drawer.reset();
+        this.imageAnalyzer.drawMode = 'line';
+        this.imageAnalyzer.setStatusMessage('ラインの始点をクリックしてください');
+    }
+
+    start(e) {
+        this.drawer.start(e);
+    }
+
+    draw(e) {
+        this.drawer.draw(e);
+    }
+
+    end(e) {
+        const line = this.drawer.end(e);
+        if (!line) return;
+        const values = PixelSampler.sample(this.imageAnalyzer, line.start, line.end);
+        if (values) {
+            this.graph.draw(values);
+            const peaks = PeakDetector.findPeaks(values.brightness);
+            this.displayPeaks(peaks);
+        }
+        this.imageAnalyzer.drawMode = 'rect';
+    }
+
+    displayPeaks(peaks) {
+        if (!this.peakInfo) return;
+        if (!peaks || peaks.length === 0) {
+            this.peakInfo.textContent = 'ピークなし';
+            return;
+        }
+        const text = peaks.map(p => `(${p.index}, ${p.value})`).join(', ');
+        this.peakInfo.textContent = `ピーク: ${text}`;
+    }
+}

--- a/js/line-profile.js
+++ b/js/line-profile.js
@@ -182,6 +182,9 @@ class LineGraph {
         const width = baseWidth * this.largeZoom;
         this.largeCanvas.width = width;
         const height = this.largeCanvas.height;
+        const padding = { top: 20, bottom: 60, left: 40, right: 20 };
+        const plotWidth = width - padding.left - padding.right;
+        const plotHeight = height - padding.top - padding.bottom;
         this.largeCtx.clearRect(0, 0, width, height);
         const maxVal = 255;
         const step = Math.max(1, Math.floor(5 / this.largeZoom));
@@ -190,18 +193,18 @@ class LineGraph {
         this.largeCtx.strokeStyle = '#dee2e6';
         this.largeCtx.lineWidth = 1;
         this.largeCtx.beginPath();
-        this.largeCtx.moveTo(0, 0);
-        this.largeCtx.lineTo(0, height);
-        this.largeCtx.lineTo(width, height);
+        this.largeCtx.moveTo(padding.left, padding.top);
+        this.largeCtx.lineTo(padding.left, height - padding.bottom);
+        this.largeCtx.lineTo(width - padding.right, height - padding.bottom);
         this.largeCtx.stroke();
 
         // 軸ラベル
         this.largeCtx.fillStyle = '#495057';
         this.largeCtx.font = '12px sans-serif';
         this.largeCtx.textAlign = 'center';
-        this.largeCtx.fillText('距離(px)', width / 2, height - 4);
+        this.largeCtx.fillText('距離(px)', padding.left + plotWidth / 2, height - padding.bottom + 35);
         this.largeCtx.save();
-        this.largeCtx.translate(12, height / 2);
+        this.largeCtx.translate(15, padding.top + plotHeight / 2);
         this.largeCtx.rotate(-Math.PI / 2);
         this.largeCtx.fillText('画素値', 0, 0);
         this.largeCtx.restore();
@@ -211,8 +214,8 @@ class LineGraph {
         const drawChannel = (data, color) => {
             this.largeCtx.beginPath();
             data.forEach((v, i) => {
-                const x = (i / (len - 1)) * width;
-                const y = height - (v / maxVal) * height;
+                const x = padding.left + (i / (len - 1)) * plotWidth;
+                const y = padding.top + (1 - v / maxVal) * plotHeight;
                 if (i === 0) this.largeCtx.moveTo(x, y);
                 else this.largeCtx.lineTo(x, y);
             });
@@ -222,17 +225,17 @@ class LineGraph {
 
             this.largeCtx.font = '10px sans-serif';
             for (let i = 0; i < len; i += step) {
-                const x = (i / (len - 1)) * width;
-                const y = height - (data[i] / maxVal) * height;
+                const x = padding.left + (i / (len - 1)) * plotWidth;
+                const y = padding.top + (1 - data[i] / maxVal) * plotHeight;
                 this.largeCtx.fillStyle = color;
                 this.largeCtx.beginPath();
                 this.largeCtx.arc(x, y, 2, 0, Math.PI * 2);
                 this.largeCtx.fill();
-                this.largeCtx.fillText(data[i], x + 2, y - 2);
+                this.largeCtx.fillText(data[i], x + 2, y - 4);
 
                 this.largeCtx.fillStyle = '#495057';
                 this.largeCtx.textAlign = 'center';
-                this.largeCtx.fillText(i, x, height - 6);
+                this.largeCtx.fillText(i, x, height - padding.bottom + 15);
                 this.largeCtx.textAlign = 'left';
             }
         };

--- a/js/main.js
+++ b/js/main.js
@@ -26,6 +26,20 @@ function closeHistogramModal() {
 }
 
 /**
+ * ラインプロファイルモーダルを閉じる（グローバル関数）
+ */
+function closeLineProfileModal() {
+    if (imageAnalyzerInstance && imageAnalyzerInstance.lineAnalyzer) {
+        imageAnalyzerInstance.lineAnalyzer.closeModal();
+    } else {
+        const modal = document.getElementById('lineProfileModal');
+        if (modal) {
+            modal.style.display = 'none';
+        }
+    }
+}
+
+/**
  * アプリケーションの初期化
  */
 function initializeApplication() {

--- a/js/ui-controls.js
+++ b/js/ui-controls.js
@@ -198,7 +198,7 @@ Object.assign(ImageAnalyzer.prototype, {
         this.currentHistogramMode = mode;
         
         // モードボタンの更新
-        const modeButtons = document.querySelectorAll('.mode-btn');
+        const modeButtons = document.querySelectorAll('.histogram-mode-selector .mode-btn');
         modeButtons.forEach(btn => {
             btn.classList.toggle('active', btn.dataset.mode === mode);
         });
@@ -216,7 +216,7 @@ Object.assign(ImageAnalyzer.prototype, {
     setUIEnabled(enabled) {
         try {
             // ヒストグラムモードボタン
-            const modeButtons = document.querySelectorAll('.mode-btn');
+            const modeButtons = document.querySelectorAll('.histogram-mode-selector .mode-btn');
             modeButtons.forEach(btn => {
                 btn.disabled = !enabled;
             });


### PR DESCRIPTION
## Summary
- add line profile panel and button
- implement LineAnalyzer for line drawing, pixel sampling, graphing and peak detection
- integrate draw mode and reset handling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/line-profile.js js/core.js js/events.js js/image-processing.js`


------
https://chatgpt.com/codex/tasks/task_e_688e2107f0488332b887f9c8f28370ed