### PR TITLE
feat: add zoom and pan to image panel

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -156,6 +156,24 @@ body {
     font-size: 0.8rem;
 }
 
+/* リセットボタン */
+.reset-button {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: #667eea;
+    color: white;
+    border: none;
+    border-radius: 15px;
+    padding: 5px 10px;
+    font-size: 0.8rem;
+    cursor: pointer;
+}
+
+.reset-button:hover {
+    background: #5a67d8;
+}
+
 /* ========================================
    解析パネル
    ======================================== */

--- a/css/styles.css
+++ b/css/styles.css
@@ -140,6 +140,10 @@ body {
     cursor: crosshair !important;
 }
 
+.panning {
+    cursor: move !important;
+}
+
 /* ステータス表示 */
 .status {
     position: absolute;

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
                 <input type="file" id="fileInput" accept="image/jpeg,image/jpg,image/png,image/bmp,image/tiff,image/tif,image/webp,image/gif" aria-label="画像ファイルを選択" style="display: none;">
 
                 <canvas id="imageCanvas" class="hidden"></canvas>
+                <button id="resetView" class="reset-button hidden">🔄 リセット</button>
                 <div id="status" class="status hidden"></div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
                 <input type="file" id="fileInput" accept="image/jpeg,image/jpg,image/png,image/bmp,image/tiff,image/tif,image/webp,image/gif" aria-label="画像ファイルを選択" style="display: none;">
 
                 <canvas id="imageCanvas" class="hidden"></canvas>
-                <button id="resetView" class="reset-button hidden">🔄 リセット</button>
+                <button id="resetView" class="reset-button hidden">🔄 画像位置リセット</button>
                 <div id="status" class="status hidden"></div>
             </div>
 

--- a/js/core.js
+++ b/js/core.js
@@ -44,6 +44,17 @@ class ImageAnalyzer {
         this.imageOffsetX = 0;
         this.imageOffsetY = 0;
         this.imageMargin = 20;
+        this.baseScale = 1;
+        this.zoom = 1;
+        this.minZoom = 0.5;
+        this.maxZoom = 5;
+        this.panX = 0;
+        this.panY = 0;
+        this.isPanning = false;
+        this.panStartX = 0;
+        this.panStartY = 0;
+        this.viewWidth = 0;
+        this.viewHeight = 0;
         
         // 描画関連
         this.isDrawing = false;

--- a/js/core.js
+++ b/js/core.js
@@ -162,6 +162,8 @@ class ImageAnalyzer {
             // UI要素のリセット
             this.canvas.classList.add('hidden');
             this.dropZone.classList.remove('hidden');
+            const resetBtn = document.getElementById('resetView');
+            if (resetBtn) resetBtn.classList.add('hidden');
             
             // ステータス表示
             this.setStatusMessage('アプリケーションをリセットしました');

--- a/js/events.js
+++ b/js/events.js
@@ -118,6 +118,7 @@ Object.assign(ImageAnalyzer.prototype, {
             if (e.button === 0) {
                 this.startDrawing(e);
             } else if (e.button === 1 || e.button === 2) {
+                e.preventDefault();
                 this.startPan(e);
             }
         });
@@ -125,6 +126,7 @@ Object.assign(ImageAnalyzer.prototype, {
         // マウスムーブ - 描画・パン・カーソル情報更新
         this.canvas.addEventListener('mousemove', (e) => {
             if (this.isPanning) {
+                e.preventDefault();
                 this.panImage(e);
             } else {
                 this.drawRectangle(e);
@@ -156,6 +158,14 @@ Object.assign(ImageAnalyzer.prototype, {
         this.canvas.addEventListener('wheel', (e) => {
             this.handleWheel(e);
         }, { passive: false });
+
+        // リセットボタン - 表示位置の初期化
+        const resetBtn = document.getElementById('resetView');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => {
+                this.resetView();
+            });
+        }
 
         // コンテキストメニュー無効化
         this.canvas.addEventListener('contextmenu', (e) => {

--- a/js/events.js
+++ b/js/events.js
@@ -113,29 +113,49 @@ Object.assign(ImageAnalyzer.prototype, {
     initCanvasEvents() {
         if (!this.canvas) return;
 
-        // マウスダウン - 矩形描画開始
+        // マウスダウン - 描画またはパン開始
         this.canvas.addEventListener('mousedown', (e) => {
-            this.startDrawing(e);
+            if (e.button === 0) {
+                this.startDrawing(e);
+            } else if (e.button === 1 || e.button === 2) {
+                this.startPan(e);
+            }
         });
 
-        // マウスムーブ - 矩形描画・カーソル情報更新
+        // マウスムーブ - 描画・パン・カーソル情報更新
         this.canvas.addEventListener('mousemove', (e) => {
-            this.drawRectangle(e);
-            this.updateCursorInfo(e);
+            if (this.isPanning) {
+                this.panImage(e);
+            } else {
+                this.drawRectangle(e);
+                this.updateCursorInfo(e);
+            }
         });
 
-        // マウスアップ - 矩形描画終了
+        // マウスアップ - 操作終了
         this.canvas.addEventListener('mouseup', (e) => {
-            this.endDrawing(e);
+            if (this.isPanning) {
+                this.endPan();
+            } else {
+                this.endDrawing(e);
+            }
         });
 
-        // マウスリーブ - 描画中止・カーソル情報クリア
+        // マウスリーブ - 操作中止・カーソル情報クリア
         this.canvas.addEventListener('mouseleave', (e) => {
+            if (this.isPanning) {
+                this.endPan();
+            }
             if (this.isDrawing) {
                 this.endDrawing(e);
             }
             this.clearCursorInfo();
         });
+
+        // ホイール - ズーム
+        this.canvas.addEventListener('wheel', (e) => {
+            this.handleWheel(e);
+        }, { passive: false });
 
         // コンテキストメニュー無効化
         this.canvas.addEventListener('contextmenu', (e) => {

--- a/js/image-processing.js
+++ b/js/image-processing.js
@@ -68,6 +68,8 @@ Object.assign(ImageAnalyzer.prototype, {
     showImageCanvas() {
         this.dropZone.classList.add('hidden');
         this.canvas.classList.remove('hidden');
+        const resetBtn = document.getElementById('resetView');
+        if (resetBtn) resetBtn.classList.remove('hidden');
     },
 
     /**

--- a/js/image-processing.js
+++ b/js/image-processing.js
@@ -124,22 +124,26 @@ Object.assign(ImageAnalyzer.prototype, {
             const scaleToFit = Math.min(displayAreaWidth / originalWidth, displayAreaHeight / originalHeight);
             const minScale = Math.min(200 / originalWidth, 150 / originalHeight);
             const finalScale = Math.max(minScale, Math.min(scaleToFit, 3.0));
-            
-            this.displayedWidth = originalWidth * finalScale;
-            this.displayedHeight = originalHeight * finalScale;
+
+            this.baseScale = finalScale;
+            this.zoom = 1;
+            this.viewWidth = originalWidth * finalScale;
+            this.viewHeight = originalHeight * finalScale;
+            this.displayedWidth = this.viewWidth;
+            this.displayedHeight = this.viewHeight;
+            this.panX = 0;
+            this.panY = 0;
 
             console.log('Display size:', this.displayedWidth, 'x', this.displayedHeight, 'Scale:', finalScale);
 
             // Canvas設定
-            this.canvas.width = this.displayedWidth + (this.imageMargin * 2);
-            this.canvas.height = this.displayedHeight + (this.imageMargin * 2);
-            this.imageOffsetX = this.imageMargin;
-            this.imageOffsetY = this.imageMargin;
+            this.canvas.width = this.viewWidth + (this.imageMargin * 2);
+            this.canvas.height = this.viewHeight + (this.imageMargin * 2);
 
             // 描画
             this.redrawCanvas();
-            
-            const statusMessage = `画像表示完了: ${Math.round(this.displayedWidth)} × ${Math.round(this.displayedHeight)} px (スケール: ${(finalScale * 100).toFixed(1)}%)`;
+
+            const statusMessage = `画像表示完了: ${Math.round(this.viewWidth)} × ${Math.round(this.viewHeight)} px (スケール: ${(finalScale * 100).toFixed(1)}%)`;
             this.setStatusMessage(statusMessage);
             
         } catch (error) {
@@ -153,30 +157,35 @@ Object.assign(ImageAnalyzer.prototype, {
      */
     redrawCanvas() {
         if (!this.currentImage) return;
-        
+
+        this.displayedWidth = this.viewWidth * this.zoom;
+        this.displayedHeight = this.viewHeight * this.zoom;
+        this.imageOffsetX = this.imageMargin + this.panX - (this.displayedWidth - this.viewWidth) / 2;
+        this.imageOffsetY = this.imageMargin + this.panY - (this.displayedHeight - this.viewHeight) / 2;
+
         // キャンバスクリア
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
-        
+
         // 背景
         this.ctx.fillStyle = '#e9ecef';
         this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
-        
+
         // 画像描画
         this.ctx.drawImage(
-            this.currentImage, 
-            this.imageOffsetX, 
-            this.imageOffsetY, 
-            this.displayedWidth, 
+            this.currentImage,
+            this.imageOffsetX,
+            this.imageOffsetY,
+            this.displayedWidth,
             this.displayedHeight
         );
-        
+
         // 画像境界線
         this.ctx.strokeStyle = '#6c757d';
         this.ctx.lineWidth = 1;
         this.ctx.strokeRect(
-            this.imageOffsetX - 0.5, 
-            this.imageOffsetY - 0.5, 
-            this.displayedWidth + 1, 
+            this.imageOffsetX - 0.5,
+            this.imageOffsetY - 0.5,
+            this.displayedWidth + 1,
             this.displayedHeight + 1
         );
     },

--- a/js/mouse-operations.js
+++ b/js/mouse-operations.js
@@ -31,6 +31,7 @@ Object.assign(ImageAnalyzer.prototype, {
     startPan(e) {
         if (!this.currentImage) return;
 
+        e.preventDefault();
         this.isPanning = true;
         const rect = this.canvas.getBoundingClientRect();
         const scaleX = this.canvas.width / rect.width;
@@ -49,6 +50,7 @@ Object.assign(ImageAnalyzer.prototype, {
     panImage(e) {
         if (!this.isPanning) return;
 
+        e.preventDefault();
         const rect = this.canvas.getBoundingClientRect();
         const scaleX = this.canvas.width / rect.width;
         const scaleY = this.canvas.height / rect.height;
@@ -61,6 +63,17 @@ Object.assign(ImageAnalyzer.prototype, {
         this.panStartX = currentX;
         this.panStartY = currentY;
 
+        this.redrawCanvas();
+    },
+
+    /**
+     * 表示を初期状態にリセット
+     */
+    resetView() {
+        if (!this.currentImage) return;
+        this.zoom = 1;
+        this.panX = 0;
+        this.panY = 0;
         this.redrawCanvas();
     },
 

--- a/js/mouse-operations.js
+++ b/js/mouse-operations.js
@@ -11,7 +11,7 @@ Object.assign(ImageAnalyzer.prototype, {
      */
     startDrawing(e) {
         if (!this.currentImage) return;
-        
+
         this.isDrawing = true;
         const rect = this.canvas.getBoundingClientRect();
         const scaleX = this.canvas.width / rect.width;
@@ -22,6 +22,67 @@ Object.assign(ImageAnalyzer.prototype, {
         
         this.canvas.classList.add('drawing');
         this.setStatusMessage('矩形を描画中...');
+    },
+
+    /**
+     * パン開始
+     * @param {MouseEvent} e - マウスイベント
+     */
+    startPan(e) {
+        if (!this.currentImage) return;
+
+        this.isPanning = true;
+        const rect = this.canvas.getBoundingClientRect();
+        const scaleX = this.canvas.width / rect.width;
+        const scaleY = this.canvas.height / rect.height;
+
+        this.panStartX = (e.clientX - rect.left) * scaleX;
+        this.panStartY = (e.clientY - rect.top) * scaleY;
+
+        this.canvas.classList.add('panning');
+    },
+
+    /**
+     * パン処理
+     * @param {MouseEvent} e - マウスイベント
+     */
+    panImage(e) {
+        if (!this.isPanning) return;
+
+        const rect = this.canvas.getBoundingClientRect();
+        const scaleX = this.canvas.width / rect.width;
+        const scaleY = this.canvas.height / rect.height;
+
+        const currentX = (e.clientX - rect.left) * scaleX;
+        const currentY = (e.clientY - rect.top) * scaleY;
+
+        this.panX += currentX - this.panStartX;
+        this.panY += currentY - this.panStartY;
+        this.panStartX = currentX;
+        this.panStartY = currentY;
+
+        this.redrawCanvas();
+    },
+
+    /**
+     * パン終了
+     */
+    endPan() {
+        this.isPanning = false;
+        this.canvas.classList.remove('panning');
+    },
+
+    /**
+     * ホイールによるズーム
+     * @param {WheelEvent} e - ホイールイベント
+     */
+    handleWheel(e) {
+        if (!this.currentImage) return;
+        e.preventDefault();
+
+        const zoomFactor = e.deltaY < 0 ? 1.1 : 0.9;
+        this.zoom = Math.min(this.maxZoom, Math.max(this.minZoom, this.zoom * zoomFactor));
+        this.redrawCanvas();
     },
 
     /**


### PR DESCRIPTION
## Summary
- add zoom and pan properties for the canvas image
- support mouse wheel zooming and right/middle drag panning
- show move cursor while panning

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e24d49d588332b6a4c797b31fc4db